### PR TITLE
Add a link to the 'creating a Drone machine user' doc on all drivers

### DIFF
--- a/content/install/amazon.md
+++ b/content/install/amazon.md
@@ -12,7 +12,7 @@ The goal of this document is to give you enough technical specifics to configure
 
 ## Create a Drone Token
 
-You need to create a Drone user token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue. If you do not know how to create a token please see our tutorial.
+You need to create a Drone user token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue. If you do not know how to create a token please see [our tutorial](https://docs.drone.io/manage/user/machine/).
 
 ## Create a Secret Access Key
 

--- a/content/install/digitalocean.md
+++ b/content/install/digitalocean.md
@@ -12,7 +12,7 @@ The goal of this document is to give you enough technical specifics to configure
 
 ## Create a Drone Token
 
-You need to create a Drone user token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue. If you do not know how to create a token please see our tutorial.
+You need to create a Drone user token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue. If you do not know how to create a token please see [our tutorial](https://docs.drone.io/manage/user/machine/).
 
 ## Create a Digital Ocean Token
 

--- a/content/install/google.md
+++ b/content/install/google.md
@@ -16,7 +16,7 @@ This document is missing instructions to provide the autoscaler with Google Clou
 
 ## Create a Drone Token
 
-You need to create a user Drone token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue. If you do not know how to create a token please see our tutorial.
+You need to create a user Drone token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue. If you do not know how to create a token please see [our tutorial](https://docs.drone.io/manage/user/machine/).
 
 # Download
 

--- a/content/install/hetzner.md
+++ b/content/install/hetzner.md
@@ -12,7 +12,7 @@ The goal of this document is to give you enough technical specifics to configure
 
 ## Create a Drone Token
 
-You need to create a Drone user token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue.
+You need to create a Drone user token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue. If you do not know how to create a token please see [our tutorial](https://docs.drone.io/manage/user/machine/).
 
 ## Create a Hetzner Token
 

--- a/content/install/openstack.md
+++ b/content/install/openstack.md
@@ -8,6 +8,10 @@ The goal of this document is to give you enough technical specifics to configure
 
 # Prerequisites
 
+## Create a Drone Token
+
+You need to create a Drone user token with administrative privilege that you can provide to the autoscaler. The autoscaler will use this token to remotely access the Drone build queue. If you do not know how to create a token please see [our tutorial](https://docs.drone.io/manage/user/machine/).
+
 {{< alert warn >}}
 This document is missing the pre-requisites for installing the autoscaler. Please consider sending a pull request to improve this documentation.
 {{</ alert >}}


### PR DESCRIPTION
Just searching "Drone user token" on Google doesn't get you obvious results, plus i find it clearer if there's a mention of a tutorial that explains things to have a direct link to it.